### PR TITLE
fix: close upstream parity audit gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,10 @@ make deploy IMG=your-registry/homer-operator:dev
 # Run unit tests
 make test
 
-# Run the black-box suite against an installed operator
+# Run the black-box suite against the documented Helm installation
+make test-e2e
+
+# For the default Kustomize installation, override the operator location
 E2E_OPERATOR_NAMESPACE=homer-operator-system \
 E2E_OPERATOR_DEPLOYMENT=homer-operator-controller-manager \
 make test-e2e

--- a/internal/controller/configmap_watch_test.go
+++ b/internal/controller/configmap_watch_test.go
@@ -1,0 +1,98 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	homerv1alpha1 "github.com/rajsinghtech/homer-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestFindDashboardsForConfigMapMatchesExternalAndAssetReferences(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := homerv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add Homer scheme: %v", err)
+	}
+
+	const dashboardNamespace = "dashboards"
+	const assetsNamespace = "shared-assets"
+	const sharedConfigMap = "shared-config"
+
+	dashboards := []client.Object{
+		&homerv1alpha1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{Name: "external-only", Namespace: dashboardNamespace},
+			Spec:       homerv1alpha1.DashboardSpec{ConfigMap: homerv1alpha1.ConfigMap{Name: sharedConfigMap}},
+		},
+		&homerv1alpha1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{Name: "asset-only", Namespace: dashboardNamespace},
+			Spec:       homerv1alpha1.DashboardSpec{Assets: &homerv1alpha1.AssetsConfig{ConfigMapRef: &homerv1alpha1.AssetConfigMapRef{Name: sharedConfigMap}}},
+		},
+		&homerv1alpha1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{Name: "both-references", Namespace: dashboardNamespace},
+			Spec: homerv1alpha1.DashboardSpec{
+				ConfigMap: homerv1alpha1.ConfigMap{Name: sharedConfigMap},
+				Assets:    &homerv1alpha1.AssetsConfig{ConfigMapRef: &homerv1alpha1.AssetConfigMapRef{Name: sharedConfigMap}},
+			},
+		},
+		&homerv1alpha1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-namespace", Namespace: "other-dashboard-namespace"},
+			Spec:       homerv1alpha1.DashboardSpec{ConfigMap: homerv1alpha1.ConfigMap{Name: sharedConfigMap}},
+		},
+		&homerv1alpha1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{Name: "cross-namespace-asset", Namespace: dashboardNamespace},
+			Spec:       homerv1alpha1.DashboardSpec{Assets: &homerv1alpha1.AssetsConfig{ConfigMapRef: &homerv1alpha1.AssetConfigMapRef{Name: "cross-assets", Namespace: assetsNamespace}}},
+		},
+	}
+
+	reconciler := &DashboardReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(dashboards...).Build(),
+		Scheme: scheme,
+	}
+
+	requests := reconciler.findDashboardsForAssetConfigMap(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: sharedConfigMap, Namespace: dashboardNamespace},
+	})
+	assertRequests(t, requests, map[client.ObjectKey]bool{
+		{Name: "external-only", Namespace: dashboardNamespace}:   true,
+		{Name: "asset-only", Namespace: dashboardNamespace}:      true,
+		{Name: "both-references", Namespace: dashboardNamespace}: true,
+	})
+
+	requests = reconciler.findDashboardsForAssetConfigMap(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cross-assets", Namespace: assetsNamespace},
+	})
+	assertRequests(t, requests, map[client.ObjectKey]bool{
+		{Name: "cross-namespace-asset", Namespace: dashboardNamespace}: true,
+	})
+
+	requests = reconciler.findDashboardsForAssetConfigMap(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: sharedConfigMap, Namespace: "unrelated-namespace"},
+	})
+	if len(requests) != 0 {
+		t.Fatalf("requests for same-named ConfigMap in another namespace = %#v, want none", requests)
+	}
+}
+
+func assertRequests(t *testing.T, requests []ctrl.Request, expected map[client.ObjectKey]bool) {
+	t.Helper()
+	if len(requests) != len(expected) {
+		t.Fatalf("got %d requests (%#v), want %d (%#v)", len(requests), requests, len(expected), expected)
+	}
+	seen := make(map[client.ObjectKey]int, len(requests))
+	for _, request := range requests {
+		seen[request.NamespacedName]++
+	}
+	for key := range expected {
+		if seen[key] != 1 {
+			t.Fatalf("request count for %s/%s = %d, want 1", key.Namespace, key.Name, seen[key])
+		}
+	}
+}

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -677,9 +677,9 @@ func (r *DashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder = builder.Watches(&corev1.Namespace{},
 		handler.EnqueueRequestsFromMapFunc(r.findDashboardsForNamespace))
 
-	// Watch referenced asset ConfigMaps, including source ConfigMaps in another
-	// namespace. This keeps owned mirrors and the resulting Dashboard current
-	// when users replace or edit their assets.
+	// Watch referenced ConfigMaps, including asset sources in another namespace.
+	// This keeps external Homer configuration, owned asset mirrors, and the
+	// resulting Dashboard current when users replace or edit their inputs.
 	builder = builder.Watches(&corev1.ConfigMap{},
 		handler.EnqueueRequestsFromMapFunc(r.findDashboardsForAssetConfigMap))
 
@@ -940,19 +940,35 @@ func (r *DashboardReconciler) findDashboardsForAssetConfigMap(ctx context.Contex
 	}
 
 	requests := make([]ctrl.Request, 0)
+	seen := make(map[client.ObjectKey]struct{})
 	for i := range dashboards.Items {
 		dashboard := &dashboards.Items[i]
+		requestKey := client.ObjectKeyFromObject(dashboard)
+
+		// External Homer configuration is always resolved from the Dashboard's
+		// namespace, so only a ConfigMap in that namespace can trigger it.
+		externalConfigMatches := dashboard.Spec.ConfigMap.Name != "" &&
+			dashboard.Spec.ConfigMap.Name == configMap.Name &&
+			dashboard.Namespace == configMap.Namespace
+
 		ref := dashboard.Spec.Assets
-		if ref == nil || ref.ConfigMapRef == nil || ref.ConfigMapRef.Name != configMap.Name {
+		assetMatches := false
+		if ref != nil && ref.ConfigMapRef != nil && ref.ConfigMapRef.Name == configMap.Name {
+			refNamespace := ref.ConfigMapRef.Namespace
+			if refNamespace == "" {
+				refNamespace = dashboard.Namespace
+			}
+			assetMatches = refNamespace == configMap.Namespace
+		}
+
+		if !externalConfigMatches && !assetMatches {
 			continue
 		}
-		refNamespace := ref.ConfigMapRef.Namespace
-		if refNamespace == "" {
-			refNamespace = dashboard.Namespace
+		if _, alreadyQueued := seen[requestKey]; alreadyQueued {
+			continue
 		}
-		if refNamespace == configMap.Namespace {
-			requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(dashboard)})
-		}
+		seen[requestKey] = struct{}{}
+		requests = append(requests, ctrl.Request{NamespacedName: requestKey})
 	}
 	return requests
 }

--- a/pkg/homer/deepcopy.go
+++ b/pkg/homer/deepcopy.go
@@ -44,12 +44,7 @@ func (c *HomerConfig) DeepCopyInto(out *HomerConfig) {
 	if c.Proxy.RawFields != nil {
 		out.Proxy.RawFields = cloneRawFields(c.Proxy.RawFields)
 	}
-	if c.Message.Mapping != nil {
-		out.Message.Mapping = cloneAnyMap(c.Message.Mapping)
-	}
-	if c.Message.RawFields != nil {
-		out.Message.RawFields = cloneRawFields(c.Message.RawFields)
-	}
+	c.Message.DeepCopyInto(&out.Message)
 	if c.Hotkey.RawFields != nil {
 		out.Hotkey.RawFields = cloneRawFields(c.Hotkey.RawFields)
 	}
@@ -121,6 +116,7 @@ func (i *Item) DeepCopyInto(out *Item) {
 		out.ArrayObjects = make(map[string][]map[string]string, len(i.ArrayObjects))
 		for key, values := range i.ArrayObjects {
 			if values == nil {
+				out.ArrayObjects[key] = nil
 				continue
 			}
 			out.ArrayObjects[key] = make([]map[string]string, len(values))
@@ -167,6 +163,7 @@ func (p *ProxyConfig) DeepCopy() *ProxyConfig {
 
 func (m *MessageConfig) DeepCopyInto(out *MessageConfig) {
 	*out = *m
+	out.RefreshInterval = deepCopyValue(m.RefreshInterval)
 	if m.Mapping != nil {
 		out.Mapping = cloneAnyMap(m.Mapping)
 	}

--- a/pkg/homer/deepcopy_test.go
+++ b/pkg/homer/deepcopy_test.go
@@ -1,0 +1,53 @@
+package homer
+
+import "testing"
+
+func TestHomerConfigDeepCopyDeepCopiesMessageRefreshInterval(t *testing.T) {
+	config := &HomerConfig{
+		Message: MessageConfig{
+			RefreshInterval: map[string]any{
+				"nested": []any{
+					map[string]any{"enabled": true},
+				},
+			},
+		},
+	}
+
+	copy := config.DeepCopy()
+	refreshInterval, ok := copy.Message.RefreshInterval.(map[string]any)
+	if !ok {
+		t.Fatalf("expected copied refresh interval to be map[string]any, got %T", copy.Message.RefreshInterval)
+	}
+	nested, ok := refreshInterval["nested"].([]any)
+	if !ok || len(nested) != 1 {
+		t.Fatalf("expected copied nested refresh interval slice, got %#v", refreshInterval["nested"])
+	}
+	nestedMap, ok := nested[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected copied nested refresh interval map, got %T", nested[0])
+	}
+	nestedMap["enabled"] = false
+
+	originalRefreshInterval := config.Message.RefreshInterval.(map[string]any)
+	originalNested := originalRefreshInterval["nested"].([]any)[0].(map[string]any)
+	if originalNested["enabled"] != true {
+		t.Fatalf("mutating the copy changed the original refresh interval: %#v", originalNested)
+	}
+}
+
+func TestItemDeepCopyPreservesNilArrayObjectsEntry(t *testing.T) {
+	item := &Item{
+		ArrayObjects: map[string][]map[string]string{
+			"quick": nil,
+		},
+	}
+
+	copy := item.DeepCopy()
+	values, ok := copy.ArrayObjects["quick"]
+	if !ok {
+		t.Fatal("expected nil ArrayObjects entry key to be preserved")
+	}
+	if values != nil {
+		t.Fatalf("expected preserved ArrayObjects entry to remain nil, got %#v", values)
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -95,6 +96,19 @@ func environmentValue(name, fallback string) string {
 	return fallback
 }
 
+func hasUpdatedDashboardConfig(config string) bool {
+	return strings.Contains(config, "title: Updated Title") &&
+		strings.Contains(config, "subtitle: Updated Subtitle") &&
+		strings.Contains(config, "footer: Updated Footer")
+}
+
+const (
+	// The defaults match the documented Helm installation. Kustomize installs
+	// and CI can target their own deployment through E2E_OPERATOR_* overrides.
+	defaultOperatorDeployment = "homer-operator"
+	defaultOperatorNamespace  = "homer-operator"
+)
+
 var _ = Describe("Homer Operator E2E Tests", func() {
 	var (
 		k8sClient client.Client
@@ -115,16 +129,16 @@ var _ = Describe("Homer Operator E2E Tests", func() {
 			By("Checking that Homer Operator deployment exists")
 			deployment := &appsv1.Deployment{}
 			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      environmentValue("E2E_OPERATOR_DEPLOYMENT", "homer-operator-controller-manager"),
-				Namespace: environmentValue("E2E_OPERATOR_NAMESPACE", "homer-operator-system"),
+				Name:      environmentValue("E2E_OPERATOR_DEPLOYMENT", defaultOperatorDeployment),
+				Namespace: environmentValue("E2E_OPERATOR_NAMESPACE", defaultOperatorNamespace),
 			}, deployment)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking that deployment is ready")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      environmentValue("E2E_OPERATOR_DEPLOYMENT", "homer-operator-controller-manager"),
-					Namespace: environmentValue("E2E_OPERATOR_NAMESPACE", "homer-operator-system"),
+					Name:      environmentValue("E2E_OPERATOR_DEPLOYMENT", defaultOperatorDeployment),
+					Namespace: environmentValue("E2E_OPERATOR_NAMESPACE", defaultOperatorNamespace),
 				}, deployment)
 				if err != nil {
 					return false
@@ -228,8 +242,6 @@ var _ = Describe("Homer Operator E2E Tests", func() {
 				return err == nil
 			}, time.Minute*2, time.Second*5).Should(BeTrue())
 
-			originalConfig := configMap.Data["config.yml"]
-
 			By("Updating Dashboard configuration")
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "e2e-update-dashboard",
@@ -244,7 +256,7 @@ var _ = Describe("Homer Operator E2E Tests", func() {
 			err = k8sClient.Update(ctx, dashboard)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Waiting for ConfigMap to be updated")
+			By("Waiting for updated Dashboard configuration")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      "e2e-update-dashboard-homer",
@@ -253,7 +265,7 @@ var _ = Describe("Homer Operator E2E Tests", func() {
 				if err != nil {
 					return false
 				}
-				return configMap.Data["config.yml"] != originalConfig
+				return hasUpdatedDashboardConfig(configMap.Data["config.yml"])
 			}, time.Minute*2, time.Second*5).Should(BeTrue())
 
 			By("Verifying updated configuration")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -89,11 +89,19 @@ func cleanupE2ETest(k8sClient client.Client, ctx context.Context, testNs string)
 	}, time.Minute, time.Second).Should(BeTrue())
 }
 
-func environmentValue(name, fallback string) string {
+func environmentValue(name string) string {
 	if value := os.Getenv(name); value != "" {
 		return value
 	}
-	return fallback
+
+	switch name {
+	case "E2E_OPERATOR_DEPLOYMENT":
+		return defaultOperatorDeployment
+	case "E2E_OPERATOR_NAMESPACE":
+		return defaultOperatorNamespace
+	default:
+		return ""
+	}
 }
 
 func hasUpdatedDashboardConfig(config string) bool {
@@ -129,16 +137,16 @@ var _ = Describe("Homer Operator E2E Tests", func() {
 			By("Checking that Homer Operator deployment exists")
 			deployment := &appsv1.Deployment{}
 			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      environmentValue("E2E_OPERATOR_DEPLOYMENT", defaultOperatorDeployment),
-				Namespace: environmentValue("E2E_OPERATOR_NAMESPACE", defaultOperatorNamespace),
+				Name:      environmentValue("E2E_OPERATOR_DEPLOYMENT"),
+				Namespace: environmentValue("E2E_OPERATOR_NAMESPACE"),
 			}, deployment)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking that deployment is ready")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      environmentValue("E2E_OPERATOR_DEPLOYMENT", defaultOperatorDeployment),
-					Namespace: environmentValue("E2E_OPERATOR_NAMESPACE", defaultOperatorNamespace),
+					Name:      environmentValue("E2E_OPERATOR_DEPLOYMENT"),
+					Namespace: environmentValue("E2E_OPERATOR_NAMESPACE"),
 				}, deployment)
 				if err != nil {
 					return false


### PR DESCRIPTION
## Summary

Closes the remaining concrete issues found during the upstream Homer parity audit.

- Watch referenced external Homer ConfigMaps so dashboard changes reconcile immediately; preserve same-namespace and cross-namespace asset watches and deduplicate requests.
- Deep-copy open-ended `message.refreshInterval` values and preserve nil `ArrayObjects` entries.
- Make the black-box E2E harness default to the documented Helm installation while retaining Kustomize/CI environment overrides.
- Make the Dashboard update assertion wait for the requested configuration values rather than unrelated ConfigMap churn.

## Verification

- `go test ./...` — passed, including 6/6 live E2E specs
- `go vet ./...` — passed
- `make manifests`
- `make build`
- `make build-installer`
- Helm lint/template — passed
- Strict kubeconform validation — passed
- CRD client dry-run — passed
- `git diff --check` — passed

Issue #10 remains open intentionally: it is Renovate's Dependency Dashboard, not a product issue.
